### PR TITLE
feat: display gyms from newest to oldest by default

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -167,7 +167,7 @@ async function fetchGyms() {
     if (!res.ok) throw new Error("Bad response from server");
 
     const gymsObj = await res.json();
-    allGyms = Object.values(gymsObj);
+    allGyms = Object.values(gymsObj).reverse(); // Reverse to show newest first
 
     currentPage = 1;
     showPage(currentPage);


### PR DESCRIPTION
@Mohamedtamer1265 

### **Why Newest First is Better**
- **User Expectations**: People naturally want to see recent content first (like social media, news, etc.)
- **Relevance**: Newer gyms are more likely to be active, relevant, and worth solving
- **Engagement**: Users are more interested in current/upcoming contests than old ones
- **Navigation**: Easier to find recent gyms without scrolling through old content

### **My Solution**
Use `.reverse()` to flip the order before displaying

### Successful build 
<img width="1536" height="961" alt="Screenshot from 2025-09-03 21-26-00" src="https://github.com/user-attachments/assets/442d2887-f015-4b6d-a072-2092791d33fc" />
